### PR TITLE
fix: add support for results stored in doc.matches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,137 @@
+# Initially taken from Github's Python gitignore file
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+docs/.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+.idea/
+toy*.py
+.DS_Store
+post/
+toy*.ipynb
+data/
+*.c
+.nes_cache
+toy*.yml
+*.tmp
+
+shell/jina-wizard.sh
+/junit/
+/tests/junit/
+/docs/chapters/proto/docs.md
+
+# IntelliJ IDEA
+*.iml
+.idea
+
+# test with config in resources
+tests/integration/crud/simple/simple_indexer/

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,3 @@ shell/jina-wizard.sh
 # IntelliJ IDEA
 *.iml
 .idea
-
-# test with config in resources
-tests/integration/crud/simple/simple_indexer/

--- a/simpleranker.py
+++ b/simpleranker.py
@@ -50,6 +50,8 @@ class SimpleRanker(Executor):
 
         for doc in docs[traversal_paths]:
             matches_of_chunks = []
+            matches_of_chunks.extend(doc.matches)
+            doc.matches.clear()
             for chunk in doc.chunks:
                 matches_of_chunks.extend(chunk.matches)
             groups = groupby(

--- a/simpleranker.py
+++ b/simpleranker.py
@@ -1,7 +1,7 @@
 __copyright__ = "Copyright (c) 2020-2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
-from itertools import groupby, chain
+from itertools import groupby
 from typing import Dict
 
 from docarray.score import NamedScore
@@ -50,21 +50,16 @@ class SimpleRanker(Executor):
 
         for doc in docs[traversal_paths]:
             matches_of_chunks = []
-            matches_no_parent = []
             for m in doc.matches:
-                if m.parent_id is not None:
-                    matches_of_chunks.append(m)
-                else:
-                    matches_no_parent.append(m)
+                matches_of_chunks.extend(m)
             doc.matches.clear()
             for chunk in doc.chunks:
                 matches_of_chunks.extend(chunk.matches)
             groups = groupby(
-                sorted(matches_of_chunks, key=lambda d: d.parent_id),
-                lambda d: d.parent_id,
+                sorted(matches_of_chunks, key=lambda d: d.parent_id or d.id),
+                lambda d: d.parent_id or d.id,
             )
-            groups_no_parent = groupby(matches_no_parent)
-            for key, group in chain(groups, groups_no_parent):
+            for key, group in groups:
                 chunk_match_list = list(group)
                 if self.ranking == 'min':
                     chunk_match_list = DocumentArray(

--- a/simpleranker.py
+++ b/simpleranker.py
@@ -50,8 +50,7 @@ class SimpleRanker(Executor):
 
         for doc in docs[traversal_paths]:
             matches_of_chunks = []
-            for m in doc.matches:
-                matches_of_chunks.extend(m)
+            matches_of_chunks.extend(doc.matches)
             doc.matches.clear()
             for chunk in doc.chunks:
                 matches_of_chunks.extend(chunk.matches)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def documents_chunk_chunk():
                     }
                 )
                 match.scores['cosine'] = NamedScore(value=random.random())
-                match.parent_id = j
+                match.parent_id = str(j)
                 chunk_chunk.matches.append(match)
             chunk.chunks.append(chunk_chunk)
         document.chunks.append(chunk)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,3 +49,22 @@ def documents_chunk_chunk():
 
     document_array.extend([document])
     return document_array
+
+
+@pytest.fixture
+def documents_no_chunk():
+    document_array = DocumentArray()
+    document = Document(tags={'query_size': 35, 'query_price': 31, 'query_brand': 1})
+    for i in range(0, 10):
+
+        match = Document(
+            tags={
+                'level': 'root',
+            }
+        )
+        match.scores['cosine'] = NamedScore(value=random.random())
+
+        document.matches.append(match)
+
+    document_array.extend([document])
+    return document_array

--- a/tests/unit/test_ranker.py
+++ b/tests/unit/test_ranker.py
@@ -64,3 +64,34 @@ def test_mean_ranking(documents_chunk, ranking):
             match = doc.matches[i]
             assert match.tags
             assert match.scores['cosine'].value == pytest.approx(mean_scores[i], 1e-5)
+
+
+@pytest.mark.parametrize('traversal_paths', ['@r'])
+@pytest.mark.parametrize('ranking', ['min', 'max'])
+def test_ranking_no_chunks(documents_no_chunk, traversal_paths, ranking):
+    ranker = SimpleRanker(
+        metric='cosine',
+        ranking=ranking,
+        traversal_paths=traversal_paths,
+    )
+    ranking_docs = documents_no_chunk
+
+    ranker.rank(ranking_docs, parameters={})
+    assert ranking_docs
+
+    for doc in ranking_docs[traversal_paths]:
+        assert doc.matches
+        for i in range(len(doc.matches) - 1):
+            match = doc.matches[i]
+            assert match.tags
+            if ranking == 'min':
+                assert (
+                    match.scores['cosine'].value
+                    <= doc.matches[i + 1].scores['cosine'].value
+                )
+            else:
+                assert (
+                    match.scores['cosine'].value
+                    >= doc.matches[i + 1].scores['cosine'].value
+                )
+


### PR DESCRIPTION
In some situations, the result of the search query is a single document d with all matches stored in d.matches.
The original logic only deals with the case when the results are stored splitly in chunks.
This pr fixes the above issues.